### PR TITLE
chore: use `gcp-sphinx-docfx-yaml`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -185,7 +185,7 @@ def docfx(session):
     """Build the docfx yaml files for this library."""
 
     session.install("-e", ".")
-    session.install("sphinx", "alabaster", "recommonmark", "sphinx-docfx-yaml")
+    session.install("sphinx", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(


### PR DESCRIPTION
makes use of the updated plugin for generating DocFX YAMLs
