### PR TITLE
chore(metadata): use valid api_shortname, add api_id

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,9 +9,9 @@
     "library_type": "GAPIC_COMBO",
     "repo": "googleapis/python-grafeas",
     "distribution_name": "grafeas",
-    "api_id": "",
+    "api_id": "containeranalysis.googleapis.com",
     "codeowner_team": "@googleapis/aap-dpes",
     "requires_billing": false,
     "default_version": "v1",
-    "api_shortname": "grafeas"
+    "api_shortname": "containeranalysis"
 }


### PR DESCRIPTION
minor updates to repo-metadata.json to resolve the linter errors surfaced in
#136

closes #136
