### PR TITLE
fix(deps): require google-api-core >= 1.31.5, >= 2.3.2 on v0 release

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,9 +65,9 @@ source_suffix = [".rst", ".md"]
 master_doc = "index"
 
 # General information about the project.
-project = u"grafeas"
-copyright = u"2019, Google"
-author = u"Google APIs"
+project = "grafeas"
+copyright = "2019, Google"
+author = "Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -258,7 +258,13 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "grafeas.tex", u"grafeas Documentation", author, "manual",)
+    (
+        master_doc,
+        "grafeas.tex",
+        "grafeas Documentation",
+        author,
+        "manual",
+    )
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -286,7 +292,15 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "grafeas", u"grafeas Documentation", [author], 1,)]
+man_pages = [
+    (
+        master_doc,
+        "grafeas",
+        "grafeas Documentation",
+        [author],
+        1,
+    )
+]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -301,7 +315,7 @@ texinfo_documents = [
     (
         master_doc,
         "grafeas",
-        u"grafeas Documentation",
+        "grafeas Documentation",
         author,
         "grafeas",
         "grafeas Library",
@@ -326,7 +340,10 @@ texinfo_documents = [
 intersphinx_mapping = {
     "python": ("http://python.readthedocs.org/en/latest/", None),
     "google-auth": ("https://google-auth.readthedocs.io/en/stable", None),
-    "google.api_core": ("https://googleapis.dev/python/google-api-core/latest/", None,),
+    "google.api_core": (
+        "https://googleapis.dev/python/google-api-core/latest/",
+        None,
+    ),
     "grpc": ("https://grpc.io/grpc/python/", None),
 }
 

--- a/grafeas/grafeas_v1/gapic/grafeas_client.py
+++ b/grafeas/grafeas_v1/gapic/grafeas_client.py
@@ -39,7 +39,9 @@ from grafeas.grafeas_v1.proto import grafeas_pb2
 from grafeas.grafeas_v1.proto import grafeas_pb2_grpc
 
 
-_GAPIC_LIBRARY_VERSION = pkg_resources.get_distribution("grafeas",).version
+_GAPIC_LIBRARY_VERSION = pkg_resources.get_distribution(
+    "grafeas",
+).version
 
 
 class GrafeasClient(object):
@@ -69,7 +71,9 @@ class GrafeasClient(object):
     def note_path(cls, project, note):
         """Return a fully-qualified note string."""
         return google.api_core.path_template.expand(
-            "projects/{project}/notes/{note}", project=project, note=note,
+            "projects/{project}/notes/{note}",
+            project=project,
+            note=note,
         )
 
     @classmethod
@@ -85,7 +89,8 @@ class GrafeasClient(object):
     def project_path(cls, project):
         """Return a fully-qualified project string."""
         return google.api_core.path_template.expand(
-            "projects/{project}", project=project,
+            "projects/{project}",
+            project=project,
         )
 
     def __init__(self, transport, client_config=None, client_info=None):
@@ -159,7 +164,7 @@ class GrafeasClient(object):
         Example:
             >>> from grafeas import grafeas_v1
             >>> from grafeas.grafeas_v1.gapic.transports import grafeas_grpc_transport
-            >>> 
+            >>>
             >>> address = "[SERVICE_ADDRESS]"
             >>> scopes = ("[SCOPE]")
             >>> transport = grafeas_grpc_transport.GrafeasGrpcTransport(address, scopes)
@@ -202,7 +207,9 @@ class GrafeasClient(object):
                 client_info=self._client_info,
             )
 
-        request = grafeas_pb2.GetOccurrenceRequest(name=name,)
+        request = grafeas_pb2.GetOccurrenceRequest(
+            name=name,
+        )
         if metadata is None:
             metadata = []
         metadata = list(metadata)
@@ -235,7 +242,7 @@ class GrafeasClient(object):
         Example:
             >>> from grafeas import grafeas_v1
             >>> from grafeas.grafeas_v1.gapic.transports import grafeas_grpc_transport
-            >>> 
+            >>>
             >>> address = "[SERVICE_ADDRESS]"
             >>> scopes = ("[SCOPE]")
             >>> transport = grafeas_grpc_transport.GrafeasGrpcTransport(address, scopes)
@@ -300,7 +307,9 @@ class GrafeasClient(object):
             )
 
         request = grafeas_pb2.ListOccurrencesRequest(
-            parent=parent, filter=filter_, page_size=page_size,
+            parent=parent,
+            filter=filter_,
+            page_size=page_size,
         )
         if metadata is None:
             metadata = []
@@ -345,7 +354,7 @@ class GrafeasClient(object):
         Example:
             >>> from grafeas import grafeas_v1
             >>> from grafeas.grafeas_v1.gapic.transports import grafeas_grpc_transport
-            >>> 
+            >>>
             >>> address = "[SERVICE_ADDRESS]"
             >>> scopes = ("[SCOPE]")
             >>> transport = grafeas_grpc_transport.GrafeasGrpcTransport(address, scopes)
@@ -385,7 +394,9 @@ class GrafeasClient(object):
                 client_info=self._client_info,
             )
 
-        request = grafeas_pb2.DeleteOccurrenceRequest(name=name,)
+        request = grafeas_pb2.DeleteOccurrenceRequest(
+            name=name,
+        )
         if metadata is None:
             metadata = []
         metadata = list(metadata)
@@ -417,7 +428,7 @@ class GrafeasClient(object):
         Example:
             >>> from grafeas import grafeas_v1
             >>> from grafeas.grafeas_v1.gapic.transports import grafeas_grpc_transport
-            >>> 
+            >>>
             >>> address = "[SERVICE_ADDRESS]"
             >>> scopes = ("[SCOPE]")
             >>> transport = grafeas_grpc_transport.GrafeasGrpcTransport(address, scopes)
@@ -468,7 +479,8 @@ class GrafeasClient(object):
             )
 
         request = grafeas_pb2.CreateOccurrenceRequest(
-            parent=parent, occurrence=occurrence,
+            parent=parent,
+            occurrence=occurrence,
         )
         if metadata is None:
             metadata = []
@@ -501,7 +513,7 @@ class GrafeasClient(object):
         Example:
             >>> from grafeas import grafeas_v1
             >>> from grafeas.grafeas_v1.gapic.transports import grafeas_grpc_transport
-            >>> 
+            >>>
             >>> address = "[SERVICE_ADDRESS]"
             >>> scopes = ("[SCOPE]")
             >>> transport = grafeas_grpc_transport.GrafeasGrpcTransport(address, scopes)
@@ -552,7 +564,8 @@ class GrafeasClient(object):
             )
 
         request = grafeas_pb2.BatchCreateOccurrencesRequest(
-            parent=parent, occurrences=occurrences,
+            parent=parent,
+            occurrences=occurrences,
         )
         if metadata is None:
             metadata = []
@@ -586,7 +599,7 @@ class GrafeasClient(object):
         Example:
             >>> from grafeas import grafeas_v1
             >>> from grafeas.grafeas_v1.gapic.transports import grafeas_grpc_transport
-            >>> 
+            >>>
             >>> address = "[SERVICE_ADDRESS]"
             >>> scopes = ("[SCOPE]")
             >>> transport = grafeas_grpc_transport.GrafeasGrpcTransport(address, scopes)
@@ -641,7 +654,9 @@ class GrafeasClient(object):
             )
 
         request = grafeas_pb2.UpdateOccurrenceRequest(
-            name=name, occurrence=occurrence, update_mask=update_mask,
+            name=name,
+            occurrence=occurrence,
+            update_mask=update_mask,
         )
         if metadata is None:
             metadata = []
@@ -674,7 +689,7 @@ class GrafeasClient(object):
         Example:
             >>> from grafeas import grafeas_v1
             >>> from grafeas.grafeas_v1.gapic.transports import grafeas_grpc_transport
-            >>> 
+            >>>
             >>> address = "[SERVICE_ADDRESS]"
             >>> scopes = ("[SCOPE]")
             >>> transport = grafeas_grpc_transport.GrafeasGrpcTransport(address, scopes)
@@ -717,7 +732,9 @@ class GrafeasClient(object):
                 client_info=self._client_info,
             )
 
-        request = grafeas_pb2.GetOccurrenceNoteRequest(name=name,)
+        request = grafeas_pb2.GetOccurrenceNoteRequest(
+            name=name,
+        )
         if metadata is None:
             metadata = []
         metadata = list(metadata)
@@ -748,7 +765,7 @@ class GrafeasClient(object):
         Example:
             >>> from grafeas import grafeas_v1
             >>> from grafeas.grafeas_v1.gapic.transports import grafeas_grpc_transport
-            >>> 
+            >>>
             >>> address = "[SERVICE_ADDRESS]"
             >>> scopes = ("[SCOPE]")
             >>> transport = grafeas_grpc_transport.GrafeasGrpcTransport(address, scopes)
@@ -791,7 +808,9 @@ class GrafeasClient(object):
                 client_info=self._client_info,
             )
 
-        request = grafeas_pb2.GetNoteRequest(name=name,)
+        request = grafeas_pb2.GetNoteRequest(
+            name=name,
+        )
         if metadata is None:
             metadata = []
         metadata = list(metadata)
@@ -824,7 +843,7 @@ class GrafeasClient(object):
         Example:
             >>> from grafeas import grafeas_v1
             >>> from grafeas.grafeas_v1.gapic.transports import grafeas_grpc_transport
-            >>> 
+            >>>
             >>> address = "[SERVICE_ADDRESS]"
             >>> scopes = ("[SCOPE]")
             >>> transport = grafeas_grpc_transport.GrafeasGrpcTransport(address, scopes)
@@ -889,7 +908,9 @@ class GrafeasClient(object):
             )
 
         request = grafeas_pb2.ListNotesRequest(
-            parent=parent, filter=filter_, page_size=page_size,
+            parent=parent,
+            filter=filter_,
+            page_size=page_size,
         )
         if metadata is None:
             metadata = []
@@ -932,7 +953,7 @@ class GrafeasClient(object):
         Example:
             >>> from grafeas import grafeas_v1
             >>> from grafeas.grafeas_v1.gapic.transports import grafeas_grpc_transport
-            >>> 
+            >>>
             >>> address = "[SERVICE_ADDRESS]"
             >>> scopes = ("[SCOPE]")
             >>> transport = grafeas_grpc_transport.GrafeasGrpcTransport(address, scopes)
@@ -972,7 +993,9 @@ class GrafeasClient(object):
                 client_info=self._client_info,
             )
 
-        request = grafeas_pb2.DeleteNoteRequest(name=name,)
+        request = grafeas_pb2.DeleteNoteRequest(
+            name=name,
+        )
         if metadata is None:
             metadata = []
         metadata = list(metadata)
@@ -1005,7 +1028,7 @@ class GrafeasClient(object):
         Example:
             >>> from grafeas import grafeas_v1
             >>> from grafeas.grafeas_v1.gapic.transports import grafeas_grpc_transport
-            >>> 
+            >>>
             >>> address = "[SERVICE_ADDRESS]"
             >>> scopes = ("[SCOPE]")
             >>> transport = grafeas_grpc_transport.GrafeasGrpcTransport(address, scopes)
@@ -1060,7 +1083,9 @@ class GrafeasClient(object):
             )
 
         request = grafeas_pb2.CreateNoteRequest(
-            parent=parent, note_id=note_id, note=note,
+            parent=parent,
+            note_id=note_id,
+            note=note,
         )
         if metadata is None:
             metadata = []
@@ -1093,7 +1118,7 @@ class GrafeasClient(object):
         Example:
             >>> from grafeas import grafeas_v1
             >>> from grafeas.grafeas_v1.gapic.transports import grafeas_grpc_transport
-            >>> 
+            >>>
             >>> address = "[SERVICE_ADDRESS]"
             >>> scopes = ("[SCOPE]")
             >>> transport = grafeas_grpc_transport.GrafeasGrpcTransport(address, scopes)
@@ -1143,7 +1168,10 @@ class GrafeasClient(object):
                 client_info=self._client_info,
             )
 
-        request = grafeas_pb2.BatchCreateNotesRequest(parent=parent, notes=notes,)
+        request = grafeas_pb2.BatchCreateNotesRequest(
+            parent=parent,
+            notes=notes,
+        )
         if metadata is None:
             metadata = []
         metadata = list(metadata)
@@ -1176,7 +1204,7 @@ class GrafeasClient(object):
         Example:
             >>> from grafeas import grafeas_v1
             >>> from grafeas.grafeas_v1.gapic.transports import grafeas_grpc_transport
-            >>> 
+            >>>
             >>> address = "[SERVICE_ADDRESS]"
             >>> scopes = ("[SCOPE]")
             >>> transport = grafeas_grpc_transport.GrafeasGrpcTransport(address, scopes)
@@ -1231,7 +1259,9 @@ class GrafeasClient(object):
             )
 
         request = grafeas_pb2.UpdateNoteRequest(
-            name=name, note=note, update_mask=update_mask,
+            name=name,
+            note=note,
+            update_mask=update_mask,
         )
         if metadata is None:
             metadata = []
@@ -1267,7 +1297,7 @@ class GrafeasClient(object):
         Example:
             >>> from grafeas import grafeas_v1
             >>> from grafeas.grafeas_v1.gapic.transports import grafeas_grpc_transport
-            >>> 
+            >>>
             >>> address = "[SERVICE_ADDRESS]"
             >>> scopes = ("[SCOPE]")
             >>> transport = grafeas_grpc_transport.GrafeasGrpcTransport(address, scopes)
@@ -1332,7 +1362,9 @@ class GrafeasClient(object):
             )
 
         request = grafeas_pb2.ListNoteOccurrencesRequest(
-            name=name, filter=filter_, page_size=page_size,
+            name=name,
+            filter=filter_,
+            page_size=page_size,
         )
         if metadata is None:
             metadata = []

--- a/grafeas/grafeas_v1/gapic/transports/grafeas_grpc_transport.py
+++ b/grafeas/grafeas_v1/gapic/transports/grafeas_grpc_transport.py
@@ -43,7 +43,7 @@ class GrafeasGrpcTransport(object):
                 credentials identify this application to the service. If none
                 are specified, the client will attempt to ascertain the
                 credentials from the environment.
-        
+
         """
         # If both `channel` and `credentials` are specified, raise an
         # exception (channels come with credentials baked in already).

--- a/grafeas/grafeas_v1/proto/attestation_pb2.py
+++ b/grafeas/grafeas_v1/proto/attestation_pb2.py
@@ -28,7 +28,9 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     serialized_pb=_b(
         '\n"grafeas_v1/proto/attestation.proto\x12\ngrafeas.v1\x1a\x1dgrafeas_v1/proto/common.proto"f\n\x0f\x41ttestationNote\x12.\n\x04hint\x18\x01 \x01(\x0b\x32 .grafeas.v1.AttestationNote.Hint\x1a#\n\x04Hint\x12\x1b\n\x13human_readable_name\x18\x01 \x01(\t"^\n\x15\x41ttestationOccurrence\x12\x1a\n\x12serialized_payload\x18\x01 \x01(\x0c\x12)\n\nsignatures\x18\x02 \x03(\x0b\x32\x15.grafeas.v1.SignatureBQ\n\rio.grafeas.v1P\x01Z8google.golang.org/genproto/googleapis/grafeas/v1;grafeas\xa2\x02\x03GRAb\x06proto3'
     ),
-    dependencies=[grafeas__v1_dot_proto_dot_common__pb2.DESCRIPTOR,],
+    dependencies=[
+        grafeas__v1_dot_proto_dot_common__pb2.DESCRIPTOR,
+    ],
 )
 
 
@@ -97,7 +99,9 @@ _ATTESTATIONNOTE = _descriptor.Descriptor(
         ),
     ],
     extensions=[],
-    nested_types=[_ATTESTATIONNOTE_HINT,],
+    nested_types=[
+        _ATTESTATIONNOTE_HINT,
+    ],
     enum_types=[],
     serialized_options=None,
     is_extendable=False,

--- a/grafeas/grafeas_v1/proto/build_pb2.py
+++ b/grafeas/grafeas_v1/proto/build_pb2.py
@@ -30,7 +30,9 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     serialized_pb=_b(
         '\n\x1cgrafeas_v1/proto/build.proto\x12\ngrafeas.v1\x1a!grafeas_v1/proto/provenance.proto"$\n\tBuildNote\x12\x17\n\x0f\x62uilder_version\x18\x01 \x01(\t"\\\n\x0f\x42uildOccurrence\x12/\n\nprovenance\x18\x01 \x01(\x0b\x32\x1b.grafeas.v1.BuildProvenance\x12\x18\n\x10provenance_bytes\x18\x02 \x01(\tBQ\n\rio.grafeas.v1P\x01Z8google.golang.org/genproto/googleapis/grafeas/v1;grafeas\xa2\x02\x03GRAb\x06proto3'
     ),
-    dependencies=[grafeas__v1_dot_proto_dot_provenance__pb2.DESCRIPTOR,],
+    dependencies=[
+        grafeas__v1_dot_proto_dot_provenance__pb2.DESCRIPTOR,
+    ],
 )
 
 

--- a/grafeas/grafeas_v1/proto/deployment_pb2.py
+++ b/grafeas/grafeas_v1/proto/deployment_pb2.py
@@ -28,7 +28,9 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     serialized_pb=_b(
         '\n!grafeas_v1/proto/deployment.proto\x12\ngrafeas.v1\x1a\x1fgoogle/protobuf/timestamp.proto"&\n\x0e\x44\x65ploymentNote\x12\x14\n\x0cresource_uri\x18\x01 \x03(\t"\xc7\x02\n\x14\x44\x65ploymentOccurrence\x12\x12\n\nuser_email\x18\x01 \x01(\t\x12/\n\x0b\x64\x65ploy_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x31\n\rundeploy_time\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0e\n\x06\x63onfig\x18\x04 \x01(\t\x12\x0f\n\x07\x61\x64\x64ress\x18\x05 \x01(\t\x12\x14\n\x0cresource_uri\x18\x06 \x03(\t\x12;\n\x08platform\x18\x07 \x01(\x0e\x32).grafeas.v1.DeploymentOccurrence.Platform"C\n\x08Platform\x12\x18\n\x14PLATFORM_UNSPECIFIED\x10\x00\x12\x07\n\x03GKE\x10\x01\x12\x08\n\x04\x46LEX\x10\x02\x12\n\n\x06\x43USTOM\x10\x03\x42Q\n\rio.grafeas.v1P\x01Z8google.golang.org/genproto/googleapis/grafeas/v1;grafeas\xa2\x02\x03GRAb\x06proto3'
     ),
-    dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,],
+    dependencies=[
+        google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,
+    ],
 )
 
 
@@ -238,7 +240,9 @@ _DEPLOYMENTOCCURRENCE = _descriptor.Descriptor(
     ],
     extensions=[],
     nested_types=[],
-    enum_types=[_DEPLOYMENTOCCURRENCE_PLATFORM,],
+    enum_types=[
+        _DEPLOYMENTOCCURRENCE_PLATFORM,
+    ],
     serialized_options=None,
     is_extendable=False,
     syntax="proto3",

--- a/grafeas/grafeas_v1/proto/grafeas_pb2.py
+++ b/grafeas/grafeas_v1/proto/grafeas_pb2.py
@@ -1742,7 +1742,9 @@ _BATCHCREATENOTESREQUEST = _descriptor.Descriptor(
         ),
     ],
     extensions=[],
-    nested_types=[_BATCHCREATENOTESREQUEST_NOTESENTRY,],
+    nested_types=[
+        _BATCHCREATENOTESREQUEST_NOTESENTRY,
+    ],
     enum_types=[],
     serialized_options=None,
     is_extendable=False,

--- a/grafeas/grafeas_v1/proto/grafeas_pb2_grpc.py
+++ b/grafeas/grafeas_v1/proto/grafeas_pb2_grpc.py
@@ -10,26 +10,26 @@ from grafeas.grafeas_v1.proto import (
 class GrafeasStub(object):
     """[Grafeas](https://grafeas.io) API.
 
-  Retrieves analysis results of Cloud components such as Docker container
-  images.
+    Retrieves analysis results of Cloud components such as Docker container
+    images.
 
-  Analysis results are stored as a series of occurrences. An `Occurrence`
-  contains information about a specific analysis instance on a resource. An
-  occurrence refers to a `Note`. A note contains details describing the
-  analysis and is generally stored in a separate project, called a `Provider`.
-  Multiple occurrences can refer to the same note.
+    Analysis results are stored as a series of occurrences. An `Occurrence`
+    contains information about a specific analysis instance on a resource. An
+    occurrence refers to a `Note`. A note contains details describing the
+    analysis and is generally stored in a separate project, called a `Provider`.
+    Multiple occurrences can refer to the same note.
 
-  For example, an SSL vulnerability could affect multiple images. In this case,
-  there would be one note for the vulnerability and an occurrence for each
-  image with the vulnerability referring to that note.
-  """
+    For example, an SSL vulnerability could affect multiple images. In this case,
+    there would be one note for the vulnerability and an occurrence for each
+    image with the vulnerability referring to that note.
+    """
 
     def __init__(self, channel):
         """Constructor.
 
-    Args:
-      channel: A grpc.Channel.
-    """
+        Args:
+          channel: A grpc.Channel.
+        """
         self.GetOccurrence = channel.unary_unary(
             "/grafeas.v1.Grafeas/GetOccurrence",
             request_serializer=grafeas__v1_dot_proto_dot_grafeas__pb2.GetOccurrenceRequest.SerializeToString,
@@ -105,119 +105,108 @@ class GrafeasStub(object):
 class GrafeasServicer(object):
     """[Grafeas](https://grafeas.io) API.
 
-  Retrieves analysis results of Cloud components such as Docker container
-  images.
+    Retrieves analysis results of Cloud components such as Docker container
+    images.
 
-  Analysis results are stored as a series of occurrences. An `Occurrence`
-  contains information about a specific analysis instance on a resource. An
-  occurrence refers to a `Note`. A note contains details describing the
-  analysis and is generally stored in a separate project, called a `Provider`.
-  Multiple occurrences can refer to the same note.
+    Analysis results are stored as a series of occurrences. An `Occurrence`
+    contains information about a specific analysis instance on a resource. An
+    occurrence refers to a `Note`. A note contains details describing the
+    analysis and is generally stored in a separate project, called a `Provider`.
+    Multiple occurrences can refer to the same note.
 
-  For example, an SSL vulnerability could affect multiple images. In this case,
-  there would be one note for the vulnerability and an occurrence for each
-  image with the vulnerability referring to that note.
-  """
+    For example, an SSL vulnerability could affect multiple images. In this case,
+    there would be one note for the vulnerability and an occurrence for each
+    image with the vulnerability referring to that note.
+    """
 
     def GetOccurrence(self, request, context):
-        """Gets the specified occurrence.
-    """
+        """Gets the specified occurrence."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListOccurrences(self, request, context):
-        """Lists occurrences for the specified project.
-    """
+        """Lists occurrences for the specified project."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteOccurrence(self, request, context):
         """Deletes the specified occurrence. For example, use this method to delete an
-    occurrence when the occurrence is no longer applicable for the given
-    resource.
-    """
+        occurrence when the occurrence is no longer applicable for the given
+        resource.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateOccurrence(self, request, context):
-        """Creates a new occurrence.
-    """
+        """Creates a new occurrence."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def BatchCreateOccurrences(self, request, context):
-        """Creates new occurrences in batch.
-    """
+        """Creates new occurrences in batch."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateOccurrence(self, request, context):
-        """Updates the specified occurrence.
-    """
+        """Updates the specified occurrence."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetOccurrenceNote(self, request, context):
         """Gets the note attached to the specified occurrence. Consumer projects can
-    use this method to get a note that belongs to a provider project.
-    """
+        use this method to get a note that belongs to a provider project.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetNote(self, request, context):
-        """Gets the specified note.
-    """
+        """Gets the specified note."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListNotes(self, request, context):
-        """Lists notes for the specified project.
-    """
+        """Lists notes for the specified project."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteNote(self, request, context):
-        """Deletes the specified note.
-    """
+        """Deletes the specified note."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateNote(self, request, context):
-        """Creates a new note.
-    """
+        """Creates a new note."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def BatchCreateNotes(self, request, context):
-        """Creates new notes in batch.
-    """
+        """Creates new notes in batch."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateNote(self, request, context):
-        """Updates the specified note.
-    """
+        """Updates the specified note."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListNoteOccurrences(self, request, context):
         """Lists occurrences referencing the specified note. Provider projects can use
-    this method to get all occurrences across consumer projects referencing the
-    specified note.
-    """
+        this method to get all occurrences across consumer projects referencing the
+        specified note.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")

--- a/grafeas/grafeas_v1/proto/package_pb2.py
+++ b/grafeas/grafeas_v1/proto/package_pb2.py
@@ -510,7 +510,9 @@ _VERSION = _descriptor.Descriptor(
     ],
     extensions=[],
     nested_types=[],
-    enum_types=[_VERSION_VERSIONKIND,],
+    enum_types=[
+        _VERSION_VERSIONKIND,
+    ],
     serialized_options=None,
     is_extendable=False,
     syntax="proto3",

--- a/grafeas/grafeas_v1/proto/provenance_pb2.py
+++ b/grafeas/grafeas_v1/proto/provenance_pb2.py
@@ -28,7 +28,9 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     serialized_pb=_b(
         '\n!grafeas_v1/proto/provenance.proto\x12\ngrafeas.v1\x1a\x1fgoogle/protobuf/timestamp.proto"\x90\x04\n\x0f\x42uildProvenance\x12\n\n\x02id\x18\x01 \x01(\t\x12\x12\n\nproject_id\x18\x02 \x01(\t\x12%\n\x08\x63ommands\x18\x03 \x03(\x0b\x32\x13.grafeas.v1.Command\x12-\n\x0f\x62uilt_artifacts\x18\x04 \x03(\x0b\x32\x14.grafeas.v1.Artifact\x12/\n\x0b\x63reate_time\x18\x05 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12.\n\nstart_time\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x65nd_time\x18\x07 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0f\n\x07\x63reator\x18\x08 \x01(\t\x12\x10\n\x08logs_uri\x18\t \x01(\t\x12-\n\x11source_provenance\x18\n \x01(\x0b\x32\x12.grafeas.v1.Source\x12\x12\n\ntrigger_id\x18\x0b \x01(\t\x12\x44\n\rbuild_options\x18\x0c \x03(\x0b\x32-.grafeas.v1.BuildProvenance.BuildOptionsEntry\x12\x17\n\x0f\x62uilder_version\x18\r \x01(\t\x1a\x33\n\x11\x42uildOptionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"\x95\x02\n\x06Source\x12#\n\x1b\x61rtifact_storage_source_uri\x18\x01 \x01(\t\x12\x37\n\x0b\x66ile_hashes\x18\x02 \x03(\x0b\x32".grafeas.v1.Source.FileHashesEntry\x12*\n\x07\x63ontext\x18\x03 \x01(\x0b\x32\x19.grafeas.v1.SourceContext\x12\x36\n\x13\x61\x64\x64itional_contexts\x18\x04 \x03(\x0b\x32\x19.grafeas.v1.SourceContext\x1aI\n\x0f\x46ileHashesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.grafeas.v1.FileHashes:\x02\x38\x01"1\n\nFileHashes\x12#\n\tfile_hash\x18\x01 \x03(\x0b\x32\x10.grafeas.v1.Hash"#\n\x04Hash\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x0c"]\n\x07\x43ommand\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0b\n\x03\x65nv\x18\x02 \x03(\t\x12\x0c\n\x04\x61rgs\x18\x03 \x03(\t\x12\x0b\n\x03\x64ir\x18\x04 \x01(\t\x12\n\n\x02id\x18\x05 \x01(\t\x12\x10\n\x08wait_for\x18\x06 \x03(\t"7\n\x08\x41rtifact\x12\x10\n\x08\x63hecksum\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\t\x12\r\n\x05names\x18\x03 \x03(\t"\x9a\x02\n\rSourceContext\x12\x38\n\ncloud_repo\x18\x01 \x01(\x0b\x32".grafeas.v1.CloudRepoSourceContextH\x00\x12\x31\n\x06gerrit\x18\x02 \x01(\x0b\x32\x1f.grafeas.v1.GerritSourceContextH\x00\x12+\n\x03git\x18\x03 \x01(\x0b\x32\x1c.grafeas.v1.GitSourceContextH\x00\x12\x35\n\x06labels\x18\x04 \x03(\x0b\x32%.grafeas.v1.SourceContext.LabelsEntry\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42\t\n\x07\x63ontext"\x8a\x01\n\x0c\x41liasContext\x12+\n\x04kind\x18\x01 \x01(\x0e\x32\x1d.grafeas.v1.AliasContext.Kind\x12\x0c\n\x04name\x18\x02 \x01(\t"?\n\x04Kind\x12\x14\n\x10KIND_UNSPECIFIED\x10\x00\x12\t\n\x05\x46IXED\x10\x01\x12\x0b\n\x07MOVABLE\x10\x02\x12\t\n\x05OTHER\x10\x04"\x93\x01\n\x16\x43loudRepoSourceContext\x12#\n\x07repo_id\x18\x01 \x01(\x0b\x32\x12.grafeas.v1.RepoId\x12\x15\n\x0brevision_id\x18\x02 \x01(\tH\x00\x12\x31\n\ralias_context\x18\x03 \x01(\x0b\x32\x18.grafeas.v1.AliasContextH\x00\x42\n\n\x08revision"\x95\x01\n\x13GerritSourceContext\x12\x10\n\x08host_uri\x18\x01 \x01(\t\x12\x16\n\x0egerrit_project\x18\x02 \x01(\t\x12\x15\n\x0brevision_id\x18\x03 \x01(\tH\x00\x12\x31\n\ralias_context\x18\x04 \x01(\x0b\x32\x18.grafeas.v1.AliasContextH\x00\x42\n\n\x08revision"4\n\x10GitSourceContext\x12\x0b\n\x03url\x18\x01 \x01(\t\x12\x13\n\x0brevision_id\x18\x02 \x01(\t"S\n\x06RepoId\x12\x34\n\x0fproject_repo_id\x18\x01 \x01(\x0b\x32\x19.grafeas.v1.ProjectRepoIdH\x00\x12\r\n\x03uid\x18\x02 \x01(\tH\x00\x42\x04\n\x02id"6\n\rProjectRepoId\x12\x12\n\nproject_id\x18\x01 \x01(\t\x12\x11\n\trepo_name\x18\x02 \x01(\tBQ\n\rio.grafeas.v1P\x01Z8google.golang.org/genproto/googleapis/grafeas/v1;grafeas\xa2\x02\x03GRAb\x06proto3'
     ),
-    dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,],
+    dependencies=[
+        google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,
+    ],
 )
 
 
@@ -362,7 +364,9 @@ _BUILDPROVENANCE = _descriptor.Descriptor(
         ),
     ],
     extensions=[],
-    nested_types=[_BUILDPROVENANCE_BUILDOPTIONSENTRY,],
+    nested_types=[
+        _BUILDPROVENANCE_BUILDOPTIONSENTRY,
+    ],
     enum_types=[],
     serialized_options=None,
     is_extendable=False,
@@ -511,7 +515,9 @@ _SOURCE = _descriptor.Descriptor(
         ),
     ],
     extensions=[],
-    nested_types=[_SOURCE_FILEHASHESENTRY,],
+    nested_types=[
+        _SOURCE_FILEHASHESENTRY,
+    ],
     enum_types=[],
     serialized_options=None,
     is_extendable=False,
@@ -960,7 +966,9 @@ _SOURCECONTEXT = _descriptor.Descriptor(
         ),
     ],
     extensions=[],
-    nested_types=[_SOURCECONTEXT_LABELSENTRY,],
+    nested_types=[
+        _SOURCECONTEXT_LABELSENTRY,
+    ],
     enum_types=[],
     serialized_options=None,
     is_extendable=False,
@@ -1026,7 +1034,9 @@ _ALIASCONTEXT = _descriptor.Descriptor(
     ],
     extensions=[],
     nested_types=[],
-    enum_types=[_ALIASCONTEXT_KIND,],
+    enum_types=[
+        _ALIASCONTEXT_KIND,
+    ],
     serialized_options=None,
     is_extendable=False,
     syntax="proto3",

--- a/grafeas/grafeas_v1/proto/upgrade_pb2.py
+++ b/grafeas/grafeas_v1/proto/upgrade_pb2.py
@@ -471,7 +471,10 @@ _WINDOWSUPDATE = _descriptor.Descriptor(
         ),
     ],
     extensions=[],
-    nested_types=[_WINDOWSUPDATE_IDENTITY, _WINDOWSUPDATE_CATEGORY,],
+    nested_types=[
+        _WINDOWSUPDATE_IDENTITY,
+        _WINDOWSUPDATE_CATEGORY,
+    ],
     enum_types=[],
     serialized_options=None,
     is_extendable=False,

--- a/grafeas/grafeas_v1/proto/vulnerability_pb2.py
+++ b/grafeas/grafeas_v1/proto/vulnerability_pb2.py
@@ -460,7 +460,9 @@ _VULNERABILITYNOTE_WINDOWSDETAIL = _descriptor.Descriptor(
         ),
     ],
     extensions=[],
-    nested_types=[_VULNERABILITYNOTE_WINDOWSDETAIL_KNOWLEDGEBASE,],
+    nested_types=[
+        _VULNERABILITYNOTE_WINDOWSDETAIL_KNOWLEDGEBASE,
+    ],
     enum_types=[],
     serialized_options=None,
     is_extendable=False,
@@ -588,7 +590,10 @@ _VULNERABILITYNOTE = _descriptor.Descriptor(
         ),
     ],
     extensions=[],
-    nested_types=[_VULNERABILITYNOTE_DETAIL, _VULNERABILITYNOTE_WINDOWSDETAIL,],
+    nested_types=[
+        _VULNERABILITYNOTE_DETAIL,
+        _VULNERABILITYNOTE_WINDOWSDETAIL,
+    ],
     enum_types=[],
     serialized_options=None,
     is_extendable=False,
@@ -917,7 +922,9 @@ _VULNERABILITYOCCURRENCE = _descriptor.Descriptor(
         ),
     ],
     extensions=[],
-    nested_types=[_VULNERABILITYOCCURRENCE_PACKAGEISSUE,],
+    nested_types=[
+        _VULNERABILITYOCCURRENCE_PACKAGEISSUE,
+    ],
     enum_types=[],
     serialized_options=None,
     is_extendable=False,

--- a/noxfile.py
+++ b/noxfile.py
@@ -139,7 +139,7 @@ def docs(session):
     """Build the docs for this library."""
 
     session.install('-e', '.')
-    session.install('sphinx', 'alabaster', 'recommonmark')
+    session.install('sphinx<3.0.0', 'alabaster', 'recommonmark')
 
     shutil.rmtree(os.path.join('docs', '_build'), ignore_errors=True)
     session.run(

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ description = "Grafeas API client library"
 version = "0.4.0"
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
-    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     'enum34; python_version < "3.4"',
 ]
 


### PR DESCRIPTION
Allow google-api-core<3.0.0dev on previous release of library. Note that this PR is to a new protected branch **v0**, not **main**.

This will be followed by a release PR and is a step towards removing https://github.com/googleapis/google-cloud-python/issues/10566